### PR TITLE
Correct default export in type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/lancedikson/bowser
 // Definitions by: Alexander P. Cerutti <https://github.com/alexandercerutti>,
 
-export = Bowser;
+export default Bowser;
 export as namespace Bowser;
 
 declare namespace Bowser {


### PR DESCRIPTION
Bowser doesn't actually export methods as named exports, they are only destructured from the `Bowser` class. The types should reflect this.

This can be seen here tripping people up:

https://github.com/aws/aws-sdk-js-v3/pull/1991