### PR TITLE
Declare `bot` as a platform

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -90,6 +90,7 @@ export const PLATFORMS_MAP = {
   mobile: 'mobile',
   desktop: 'desktop',
   tv: 'tv',
+  bot: 'bot',
 };
 
 export const OS_MAP = {

--- a/src/parser-platforms.js
+++ b/src/parser-platforms.js
@@ -12,7 +12,7 @@ export default [
     test: [/googlebot/i],
     describe() {
       return {
-        type: 'bot',
+        type: PLATFORMS_MAP.bot,
         vendor: 'Google',
       };
     },


### PR DESCRIPTION
### Context
The [main docs](https://github.com/bowser-js/bowser#browser-names-for-satisfies) link to full list of aliases available in [`constants.js`](https://github.com/bowser-js/bowser/blob/master/src/constants.js). Now, the platforms defined there are incomplete since `Googlebot` is detected as a `bot` platform.