### PR TITLE
fix: restore ES5 output for bundled.js, close exports-map gaps, and cover all build artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,10 @@
     "./src/parser-platforms": "./src/parser-platforms.js",
     "./src/utils.js": "./src/utils.js",
     "./src/utils": "./src/utils.js",
+    "./LICENSE": "./LICENSE",
+    "./README.md": "./README.md",
+    "./index.d.ts": "./index.d.ts",
+    "./index.d.mts": "./index.d.mts",
     "./package.json": "./package.json"
   },
   "repository": {

--- a/test/acceptance/test-list-of-ua.js
+++ b/test/acceptance/test-list-of-ua.js
@@ -2,7 +2,41 @@ import test from 'ava';
 import yaml from 'yamljs';
 import path from 'path';
 import Bowser from '../../src/bowser';
-import BowserBuild from '../../es5';
+import BowserEs5 from '../../es5';
+import BowserBundled from '../../bundled';
+import BowserMjs from '../../bowser.mjs';
+
+/**
+ * Every published JS artifact is built from `src/` through a different
+ * pipeline — raw ES modules, babel + terser UMD, UMD with core-js baked in,
+ * and the rolldown ESM build. A regression in any one of them ships silently
+ * unless each is asserted against the spec independently.
+ *
+ * `bowser.mjs` matters most: it is what the `import` condition of the exports
+ * map resolves to, so it is the file every modern ESM and bundler consumer
+ * actually runs. Testing only `src/` and `es5.js` leaves it uncovered.
+ *
+ * These are build outputs, so `pnpm build` has to run before `pnpm test`.
+ * Importing `bowser.mjs` from this CommonJS test file relies on Node's
+ * require(esm) support (Node >= 22.12) — the build toolchain already requires
+ * a newer Node than that, so anything able to produce these files can load them.
+ */
+const artifacts = [
+  ['src/bowser.js', Bowser],
+  ['es5.js', BowserEs5],
+  ['bundled.js', BowserBundled],
+  ['bowser.mjs', BowserMjs],
+];
+
+// A missing build output fails at import with a plain "Cannot find module".
+// This catches the quieter failure: an artifact that loads but is not the
+// Bowser class — a broken UMD wrapper or a lost CJS interop unwrap would
+// otherwise make every assertion below vacuous instead of failing.
+artifacts.forEach(([name, artifact]) => {
+  if (typeof artifact !== 'function' || typeof artifact.parse !== 'function') {
+    throw new Error(`${name} did not load as the Bowser class — run \`pnpm build\` first`);
+  }
+});
 
 const listOfUA = yaml.load(path.join(__dirname, 'useragentstrings.yml'));
 
@@ -11,11 +45,10 @@ const browserNames = Object.keys(listOfUA);
 browserNames.forEach((browserName) => {
   listOfUA[browserName].forEach((browser, index) => {
     test(`Test ${browserName} ${index}`, (t) => {
-      const parsed = Bowser.parse(browser.ua);
-      const parsedBuild = BowserBuild.parse(browser.ua);
-      t.deepEqual(parsed, browser.spec, `${browser.ua}`);
-      t.deepEqual(parsedBuild, browser.spec, `${browser.ua}`);
-      t.is(parsed.browser.name, browserName, `${browser.ua}`);
+      artifacts.forEach(([name, artifact]) => {
+        t.deepEqual(artifact.parse(browser.ua), browser.spec, `${name}: ${browser.ua}`);
+      });
+      t.is(Bowser.parse(browser.ua).browser.name, browserName, `${browser.ua}`);
     });
   });
 });

--- a/test/package/assertions.cjs
+++ b/test/package/assertions.cjs
@@ -93,6 +93,19 @@ check('require.resolve("bowser/package.json") works', function () {
   assert.ok(fs.existsSync(require.resolve('bowser/package.json')));
 });
 
+// Before the exports map existed, *every* published file was reachable by
+// subpath. An exports map is a closed list, so anything published but not
+// enumerated silently becomes ERR_PACKAGE_PATH_NOT_EXPORTED. These four are
+// not code, but they did resolve on every previous version — license and
+// attribution tooling and `/// <reference types="bowser/index.d.ts" />`
+// consumers can all depend on them.
+['bowser/LICENSE', 'bowser/README.md', 'bowser/index.d.ts', 'bowser/index.d.mts']
+  .forEach(function (id) {
+    check('resolves "' + id + '"', function () {
+      assert.ok(fs.existsSync(require.resolve(id)));
+    });
+  });
+
 // --- The published manifest ------------------------------------------------
 
 check('main/browser/module/types fields are unchanged', function () {


### PR DESCRIPTION
Consolidated follow-up to the dual packaging change (#628), from a consumer-facing regression sweep of the packed tarball against published `bowser@2.14.1`.

**Parsing behaviour itself is clean.** A 270-UA corpus diff against 2.14.1 shows 5 differences, all traceable to the Motorola Edge (#612), HeyTap/Vivo (#621) and Ladybird (#627) commits. Everything below is packaging and build output.

---

## 1. `bundled.js` was not ES5 — shipping bug, regression from #628

`bundled.js` parses at `ecmaVersion: 2015` but **not** at `5`:

```js
var t=(t,e)=>()=>(e||(t((e={exports:{}}).exports,e),t=null),e.exports)
```

That is rolldown's `__commonJS` interop helper. `@rolldown/plugin-babel` only transforms *input modules*; rolldown appends the helper afterwards, and terser's `ecma: 5` avoids *introducing* newer syntax but does not transpile. `es5.js` has no CommonJS dependencies, never gets the helper, and was unaffected — which is why this went unnoticed.

The failure is total, not partial: in an ES5 engine the entire script is a SyntaxError, so the bundle whose only reason to exist is serving those engines with polyfills does not load there at all.

| | 2.14.1 | `master` | this PR |
|---|---|---|---|
| `es5.js` parses as ES5 | ✅ | ✅ | ✅ |
| `bundled.js` parses as ES5 | ✅ | ❌ | ✅ |

Fixed with a babel `renderChunk` pass after bundling and before terser, so rolldown's own helpers get lowered too. **+2.8 kB (+1.6%)** on `bundled.js`; `es5.js` unchanged.

## 2. The exports map dropped three previously-reachable files

An exports map is a closed list. Before #628 there was none, so every published file was reachable by subpath.

| Path | 2.14.1 | `master` | this PR |
|---|---|---|---|
| `bowser/LICENSE` | resolves | `ERR_PACKAGE_PATH_NOT_EXPORTED` | resolves |
| `bowser/README.md` | resolves | `ERR_PACKAGE_PATH_NOT_EXPORTED` | resolves |
| `bowser/index.d.ts` | resolves | `ERR_PACKAGE_PATH_NOT_EXPORTED` | resolves |
| `bowser/index.d.mts` | (not published) | `ERR_PACKAGE_PATH_NOT_EXPORTED` | resolves |

No documented API regressed and types still resolve in all five TS modes (`pkg.types` is a direct file path). But `/// <reference types="bowser/index.d.ts" />` and license tooling that resolves by specifier did break. Confirmed fixed under Yarn PnP, which enforces exports maps strictly.

## 3. Two of four build artifacts were untested

`test-list-of-ua.js` asserted `src/bowser.js` and `es5.js` against the UA corpus, but not `bundled.js` or `bowser.mjs`. `bowser.mjs` is what the `import` condition resolves to — every bundle I built across webpack, rollup, vite and esbuild inlines it, none fall back to `es5.js`. A regression confined to it kept CI green. All four are now asserted.

## 4. New guards for what the old ones missed

- **ES5 syntax** — the previous guard was a grep for backticks, which arrow functions walk straight past. Now an acorn parse at `ecmaVersion: 5` over both legacy bundles, plus a tokeniser check for genuine template literals (backticks inside core-js *string* literals are fine — 2.14.1 shipped three).
- **ES5 runtime APIs** — a separate failure mode syntax checks cannot see. preset-env lowers syntax but never polyfills library calls, so one `Array.prototype.includes` in the parser compiles cleanly and throws on old browsers. Both bundles now run in a `vm` context with post-ES5.1 globals, statics and prototype methods deleted; `bundled.js` must additionally *install* the polyfills its README entry promises.
- **Consumer type-checks in CI** — attw checks that types *resolve* per condition but compiles nothing. A real consumer is now compiled against the packed tarball under `node10`, `node16` (CJS and ESM), `nodenext` and `bundler`, with `skipLibCheck: false`. Negative cases included: the maps must stay non-importable as named exports, the line `index.d.mts` draws deliberately.

---

## Verification

Every guard was broken on purpose to prove it fails:

| Injected fault | Result |
|---|---|
| Revert the build fix | `bundled.js parses as ES5` fails; passes on restore |
| `Array.prototype.includes` in `es5.js` | ES5 runtime sandbox fails; passes on restore |
| Chrome regression in `bowser.mjs` only | suite red, labelled `bowser.mjs:`; green on restore |
| Chrome regression in `bundled.js` only | suite red, labelled `bundled.js:`; green on restore |
| `parse` removed from `index.d.mts` | 3 ESM modes fail, CJS modes correctly still pass |
| Pre-fix tarball vs smoke assertions | exit 1 vs exit 0 |

Full gate: `lint`, `build`, `test` (**355 passed**), `test/types/check.mjs` (**10 checks**), package smoke on Node 12.22 / 16 / 18 / 20 / 22 (**29 checks, all exit 0**), `publint` exit 0 with no new warnings, `attw --profile node16` 🟢.

Also re-verified against the final tarball: cross-artifact parity over 270 UAs (0 mismatches on `parse()` and `satisfies()` × 6 trees); webpack / rollup / vite / esbuild builds; real-browser load of all three artifacts; dual-package (CJS + ESM together) equivalence; **Bun** (ESM, CJS interop, subpaths, TS) and **Yarn PnP** all green.

## Investigated, deliberately not changed

- **`bundled.js` grew 124.5 kB → 174.1 kB in #628** (before this PR; my fix is 2.8 kB of it). Root cause is the deprecated `@babel/polyfill` (core-js **2**) being replaced by `core-js/stable` (core-js **3**), whose stable surface is genuinely larger — `globalThis`, `Object.fromEntries`, `URLSearchParams` are all new. `useBuiltIns: 'usage'` would shrink it a long way and would be wrong: the README tells consumers to use `bundled.js` precisely when they have no polyfills of their own. Documented in `tsdown.config.ts`.
- **`src/*.js` is ESM inside a CJS package** — the 14 publint warnings, the Yarn PnP `ERR_REQUIRE_CYCLE_MODULE`, and the Node < 20.19 failures all stem from this. Verified identical on 2.14.1, so it is longstanding rather than new. The obvious fix, a nested `src/package.json` with `"type": "module"`, would stop `@babel/register` loading `src/` and take the whole AVA suite with it. Documented where it bites.

## Known gaps this PR does not close

- **No real old-browser testing.** `testem` is in the repo but is not in any workflow, and its launcher only runs AVA in TAP mode. The vm sandbox is a strong proxy but is still Node, not IE11 — closing this properly needs a BrowserStack/Sauce or Playwright job.
- **Bundler resolution is not in CI.** Verified manually here across four bundlers, but wiring it up would mean adding webpack, rollup, vite and esbuild as devDependencies to an otherwise dependency-free library. Flagging rather than deciding.
- **CHANGELOG is stale since 2.11.0** and no recent PR touches it, so I have not invented a convention here.